### PR TITLE
Build from Node 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:argon
+FROM node:7
 
 # Install app dependencies
 RUN mkdir /express-app


### PR DESCRIPTION
As of yesterday, npm silently fails to install firebase's dependencies when this builds with Node 4. No idea why...